### PR TITLE
feat(generator): support custom node generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,23 @@ const excalidrawJson = convertPlanToExcalidraw(executionPlan, {
 });
 ```
 
+**With Custom Node Generators:**
+
+```typescript
+import { convertPlanToExcalidraw } from 'plan-viz';
+import { MyCustomExecGenerator } from './my-custom-exec-generator';
+
+const excalidrawJson = convertPlanToExcalidraw(executionPlan, {
+  generator: {
+    customGenerators: [
+      { operator: 'MyCustomExec', generator: new MyCustomExecGenerator() },
+    ],
+  },
+});
+```
+
+Custom generators implement `NodeGeneratorStrategy`. They are registered after built-in generators, so registering the same operator key as a built-in replaces the built-in renderer for that conversion.
+
 ### As a CLI
 
 **After package installation `npm install plan-viz`:**
@@ -241,6 +258,10 @@ interface ConverterConfig {
     detailsFontSize?: number;         // Default: 14 (for properties/details)
     nodeColor?: string;               // Default: '#1971c2'
     arrowColor?: string;              // Default: '#495057'
+    customGenerators?: Array<{
+      operator: string;
+      generator: NodeGeneratorStrategy;
+    }>;
   };
 }
 ```
@@ -399,4 +420,3 @@ Created with ❤️ for the Apache DataFusion community
 ## Changelog
 
 See [CHANGELOG.md](CHANGELOG.md) for a detailed history of changes.
-

--- a/src/generators/__tests__/excalidraw.generator.core.test.ts
+++ b/src/generators/__tests__/excalidraw.generator.core.test.ts
@@ -2,6 +2,66 @@ import { ExcalidrawGenerator } from '../excalidraw.generator';
 import { ExcalidrawElement } from '../../types/excalidraw.types';
 import { TestHelpers } from './utils/test-helpers';
 import { NodeBuilder } from './builders/node.builder';
+import { BaseNodeGenerator as PublicBaseNodeGenerator } from '../../index';
+import type {
+  ExecutionPlanNode as PublicExecutionPlanNode,
+  GenerationContext as PublicGenerationContext,
+  NodeGeneratorStrategy as PublicNodeGeneratorStrategy,
+  NodeInfo as PublicNodeInfo,
+} from '../../index';
+
+class TestCustomNodeGenerator extends PublicBaseNodeGenerator {
+  constructor(private readonly label: string) {
+    super();
+  }
+
+  generate(
+    node: PublicExecutionPlanNode,
+    x: number,
+    y: number,
+    _isRoot: boolean,
+    context: PublicGenerationContext
+  ): PublicNodeInfo {
+    const nodeWidth = context.config.nodeWidth;
+    const nodeHeight = context.config.nodeHeight;
+    const rectId = context.idGenerator.generateId();
+
+    context.elements.push(context.elementFactory.createRectangle({
+      id: rectId,
+      x,
+      y,
+      width: nodeWidth,
+      height: nodeHeight,
+      strokeColor: context.config.nodeColor,
+    }));
+    context.elements.push(context.elementFactory.createText({
+      id: context.idGenerator.generateId(),
+      x,
+      y: y + 5,
+      width: nodeWidth,
+      height: context.config.operatorFontSize + 4,
+      text: `${this.label}: ${node.operator}`,
+      fontSize: context.config.operatorFontSize,
+      fontFamily: 7,
+      textAlign: 'center',
+      verticalAlign: 'top',
+      containerId: rectId,
+      strokeColor: context.config.nodeColor,
+    }));
+
+    return {
+      x,
+      y,
+      width: nodeWidth,
+      height: nodeHeight,
+      rectId,
+      inputArrowCount: 1,
+      inputArrowPositions: [x + nodeWidth / 2],
+      outputColumns: [],
+      outputSortOrder: [],
+    };
+  }
+}
 
 describe('ExcalidrawGenerator - Core', () => {
   let generator: ExcalidrawGenerator;
@@ -142,6 +202,57 @@ describe('ExcalidrawGenerator - Core', () => {
       // operatorFontSize should be 1.25 * fontSize = 25
       expect(operatorText?.fontSize).toBe(25);
     });
+
+    it('should use a custom generator for an unrecognized operator', () => {
+      const customGenerator = TestHelpers.createGenerator({
+        customGenerators: [
+          {
+            operator: 'CustomExec',
+            generator: new TestCustomNodeGenerator('custom'),
+          },
+        ],
+      });
+
+      const node = NodeBuilder.createSimpleNode('CustomExec');
+      const result = customGenerator.generate(node);
+      const textElements = TestHelpers.getTextElements(result.elements);
+
+      expect(textElements.some((text) => text.text === 'custom: CustomExec')).toBe(true);
+      expect(textElements.some((text) => text.text === 'unimplemented')).toBe(false);
+    });
+
+    it('should allow a custom generator to override a built-in operator', () => {
+      const customGenerator = TestHelpers.createGenerator({
+        customGenerators: [
+          {
+            operator: 'FilterExec',
+            generator: new TestCustomNodeGenerator('override'),
+          },
+        ],
+      });
+
+      const node = NodeBuilder.createNodeWithChildren('FilterExec', [], 0, {
+        predicate: 'a > 10',
+      });
+      const result = customGenerator.generate(node);
+      const textElements = TestHelpers.getTextElements(result.elements);
+
+      expect(textElements.some((text) => text.text === 'override: FilterExec')).toBe(true);
+      expect(textElements.some((text) => text.text.includes('a > 10'))).toBe(false);
+    });
+
+    it('should expose the extension API from the package entry point', () => {
+      const generator: PublicNodeGeneratorStrategy = new TestCustomNodeGenerator('public');
+      const node: PublicExecutionPlanNode = NodeBuilder.createSimpleNode('PublicExec');
+      const acceptsPublicTypes = (
+        _generator: PublicNodeGeneratorStrategy,
+        _node?: PublicExecutionPlanNode,
+        _context?: PublicGenerationContext,
+        _info?: PublicNodeInfo
+      ): boolean => true;
+
+      expect(generator).toBeInstanceOf(PublicBaseNodeGenerator);
+      expect(acceptsPublicTypes(generator, node)).toBe(true);
+    });
   });
 });
-

--- a/src/generators/builders/__tests__/detail-text.builder.test.ts
+++ b/src/generators/builders/__tests__/detail-text.builder.test.ts
@@ -1,13 +1,13 @@
 import { DetailTextBuilder } from '../detail-text.builder';
 import { ElementFactory } from '../../factories/element.factory';
 import { IdGenerator } from '../../utils/id.generator';
-import { ExcalidrawConfig } from '../../../types/excalidraw.types';
+import { ResolvedExcalidrawConfig } from '../../../types/excalidraw.types';
 
 describe('DetailTextBuilder', () => {
   let builder: DetailTextBuilder;
   let elementFactory: ElementFactory;
   let idGenerator: IdGenerator;
-  let config: Required<ExcalidrawConfig>;
+  let config: ResolvedExcalidrawConfig;
 
   beforeEach(() => {
     idGenerator = new IdGenerator();
@@ -104,4 +104,3 @@ describe('DetailTextBuilder', () => {
     });
   });
 });
-

--- a/src/generators/excalidraw.generator.ts
+++ b/src/generators/excalidraw.generator.ts
@@ -2,6 +2,7 @@ import {
   ExcalidrawData,
   ExcalidrawElement,
   ExcalidrawConfig,
+  ResolvedExcalidrawConfig,
 } from '../types/excalidraw.types';
 import { ExecutionPlanNode } from '../types/execution-plan.types';
 import { IdGenerator } from './utils/id.generator';
@@ -36,7 +37,7 @@ import { GenerationContext } from './types/generation-context.types';
  * Follows Single Responsibility Principle - coordinates generation without implementing details
  */
 export class ExcalidrawGenerator {
-  private readonly config: Required<ExcalidrawConfig>;
+  private readonly config: ResolvedExcalidrawConfig;
   private readonly idGenerator: IdGenerator;
   private readonly textMeasurement: TextMeasurement;
   private readonly elementFactory: ElementFactory;
@@ -59,6 +60,7 @@ export class ExcalidrawGenerator {
       nodeColor: config.nodeColor ?? '#1e1e1e',
       arrowColor: config.arrowColor ?? '#1e1e1e',
     };
+    const customGenerators = config.customGenerators ?? [];
 
     // Initialize utility instances
     this.idGenerator = new IdGenerator();
@@ -72,6 +74,10 @@ export class ExcalidrawGenerator {
     // Initialize node generator registry
     this.nodeGeneratorRegistry = new NodeGeneratorRegistry();
     this.registerNodeGenerators();
+
+    for (const { operator, generator } of customGenerators) {
+      this.nodeGeneratorRegistry.register(operator, generator);
+    }
   }
 
   /**

--- a/src/generators/factories/__tests__/element.factory.test.ts
+++ b/src/generators/factories/__tests__/element.factory.test.ts
@@ -1,11 +1,11 @@
 import { ElementFactory } from '../element.factory';
 import { IdGenerator } from '../../utils/id.generator';
-import { ExcalidrawConfig } from '../../../types/excalidraw.types';
+import { ResolvedExcalidrawConfig } from '../../../types/excalidraw.types';
 
 describe('ElementFactory', () => {
   let factory: ElementFactory;
   let idGenerator: IdGenerator;
-  let config: Required<ExcalidrawConfig>;
+  let config: ResolvedExcalidrawConfig;
 
   beforeEach(() => {
     idGenerator = new IdGenerator();
@@ -204,4 +204,3 @@ describe('ElementFactory', () => {
     });
   });
 });
-

--- a/src/generators/factories/element.factory.ts
+++ b/src/generators/factories/element.factory.ts
@@ -3,7 +3,7 @@ import {
   ExcalidrawText,
   ExcalidrawArrow,
   ExcalidrawEllipse,
-  ExcalidrawConfig,
+  ResolvedExcalidrawConfig,
 } from '../../types/excalidraw.types';
 import { IdGenerator } from '../utils/id.generator';
 import {
@@ -72,7 +72,7 @@ export interface EllipseOptions {
 export class ElementFactory {
   constructor(
     private idGenerator: IdGenerator,
-    private config: Required<ExcalidrawConfig>
+    private config: ResolvedExcalidrawConfig
   ) {}
 
   /**
@@ -305,4 +305,3 @@ export class ElementFactory {
     });
   }
 }
-

--- a/src/generators/index.ts
+++ b/src/generators/index.ts
@@ -1,1 +1,6 @@
 export * from './excalidraw.generator';
+export { BaseNodeGenerator } from './generators/base-node.generator';
+export type { NodeGeneratorStrategy } from './generators/node-generator.strategy';
+export type { GenerationContext } from './types/generation-context.types';
+export type { NodeInfo } from './types/node-info.types';
+export type { ExecutionPlanNode } from '../types/execution-plan.types';

--- a/src/generators/renderers/__tests__/column-label.renderer.test.ts
+++ b/src/generators/renderers/__tests__/column-label.renderer.test.ts
@@ -2,14 +2,14 @@ import { ColumnLabelRenderer } from '../column-label.renderer';
 import { ElementFactory } from '../../factories/element.factory';
 import { TextMeasurement } from '../../utils/text-measurement';
 import { IdGenerator } from '../../utils/id.generator';
-import { ExcalidrawConfig } from '../../../types/excalidraw.types';
+import { ResolvedExcalidrawConfig } from '../../../types/excalidraw.types';
 
 describe('ColumnLabelRenderer', () => {
   let renderer: ColumnLabelRenderer;
   let elementFactory: ElementFactory;
   let textMeasurement: TextMeasurement;
   let idGenerator: IdGenerator;
-  let config: Required<ExcalidrawConfig>;
+  let config: ResolvedExcalidrawConfig;
 
   beforeEach(() => {
     idGenerator = new IdGenerator();
@@ -142,4 +142,3 @@ describe('ColumnLabelRenderer', () => {
     });
   });
 });
-

--- a/src/generators/types/generation-context.types.ts
+++ b/src/generators/types/generation-context.types.ts
@@ -1,5 +1,4 @@
-import { ExcalidrawElement } from '../../types/excalidraw.types';
-import { ExcalidrawConfig } from '../../types/excalidraw.types';
+import { ExcalidrawElement, ResolvedExcalidrawConfig } from '../../types/excalidraw.types';
 import { ExecutionPlanNode } from '../../types/execution-plan.types';
 import { ElementFactory } from '../factories/element.factory';
 import { PropertyParser } from '../utils/property.parser';
@@ -30,7 +29,7 @@ export interface GenerationContext {
   /** Geometry utilities */
   geometryUtils: GeometryUtils;
   /** Configuration */
-  config: Required<ExcalidrawConfig>;
+  config: ResolvedExcalidrawConfig;
   /** Elements array to add generated elements to */
   elements: ExcalidrawElement[];
   /** Recursive generator function for processing child nodes */
@@ -41,4 +40,3 @@ export interface GenerationContext {
     isRoot: boolean
   ) => NodeInfo;
 }
-

--- a/src/services/__tests__/converter.service.test.ts
+++ b/src/services/__tests__/converter.service.test.ts
@@ -1,6 +1,63 @@
 import { ConverterService } from '../converter.service';
 import * as fs from 'fs';
 import * as path from 'path';
+import type {
+  ExecutionPlanNode,
+  GenerationContext,
+  NodeGeneratorStrategy,
+  NodeInfo,
+} from '../../index';
+
+function createLabelGenerator(label: string): NodeGeneratorStrategy {
+  return {
+    generate(
+      node: ExecutionPlanNode,
+      x: number,
+      y: number,
+      _isRoot: boolean,
+      context: GenerationContext
+    ): NodeInfo {
+      const nodeWidth = context.config.nodeWidth;
+      const nodeHeight = context.config.nodeHeight;
+      const rectId = context.idGenerator.generateId();
+
+      context.elements.push(context.elementFactory.createRectangle({
+        id: rectId,
+        x,
+        y,
+        width: nodeWidth,
+        height: nodeHeight,
+        strokeColor: context.config.nodeColor,
+      }));
+      context.elements.push(context.elementFactory.createText({
+        id: context.idGenerator.generateId(),
+        x,
+        y: y + 5,
+        width: nodeWidth,
+        height: context.config.operatorFontSize + 4,
+        text: `${label}: ${node.operator}`,
+        fontSize: context.config.operatorFontSize,
+        fontFamily: 7,
+        textAlign: 'center',
+        verticalAlign: 'top',
+        containerId: rectId,
+        strokeColor: context.config.nodeColor,
+      }));
+
+      return {
+        x,
+        y,
+        width: nodeWidth,
+        height: nodeHeight,
+        rectId,
+        inputArrowCount: 1,
+        inputArrowPositions: [x + nodeWidth / 2],
+        outputColumns: [],
+        outputSortOrder: [],
+      };
+    },
+  };
+}
 
 describe('ConverterService', () => {
   let converter: ConverterService;
@@ -112,6 +169,25 @@ describe('ConverterService', () => {
       expect(rectangle?.width).toBe(300);
       expect(rectangle?.height).toBe(120);
       expect(rectangle?.strokeColor).toBe('#ff0000');
+    });
+
+    it('should pass custom generator configuration through to ExcalidrawGenerator', () => {
+      const customConverter = new ConverterService({
+        generator: {
+          customGenerators: [
+            {
+              operator: 'ServiceCustomExec',
+              generator: createLabelGenerator('service-custom'),
+            },
+          ],
+        },
+      });
+
+      const result = customConverter.convert('ServiceCustomExec');
+      const textElements = result.elements.filter((el) => el.type === 'text');
+
+      expect(textElements.some((text) => text.text === 'service-custom: ServiceCustomExec')).toBe(true);
+      expect(textElements.some((text) => text.text === 'unimplemented')).toBe(false);
     });
   });
 

--- a/src/types/excalidraw.types.ts
+++ b/src/types/excalidraw.types.ts
@@ -1,3 +1,5 @@
+import type { NodeGeneratorStrategy } from '../generators/generators/node-generator.strategy';
+
 /**
  * Excalidraw element types
  */
@@ -126,4 +128,17 @@ export interface ExcalidrawConfig {
   nodeColor?: string;
   /** Default arrow color */
   arrowColor?: string;
+  /**
+   * Custom node generators to register after built-in generators.
+   * If a custom generator uses the same operator key as a built-in generator,
+   * the custom generator overrides the built-in generator.
+   */
+  customGenerators?: Array<{ operator: string; generator: NodeGeneratorStrategy }>;
 }
+
+/**
+ * Fully resolved rendering config passed to node generators.
+ * Extension registration is consumed by ExcalidrawGenerator and is not part of
+ * the per-node rendering context.
+ */
+export type ResolvedExcalidrawConfig = Required<Omit<ExcalidrawConfig, 'customGenerators'>>;


### PR DESCRIPTION
## Summary

This PR adds a generic extension point for rendering custom physical-plan operators without adding downstream-specific operator logic to plan-viz.

- Adds a `customGenerators` option to the Excalidraw generator config.
- Registers custom generators after built-in generators so downstream users can render new operators or override a built-in renderer for their own application.
- Exports the public types/classes needed to implement custom renderers: `BaseNodeGenerator`, `NodeGeneratorStrategy`, `GenerationContext`, `NodeInfo`, and `ExecutionPlanNode`.
- Keeps extension registration out of per-node rendering config with `ResolvedExcalidrawConfig`.
- Documents the custom generator pattern in the README.

## Why

Some DataFusion users extend the engine with custom physical operators. plan-viz already has built-in renderers for common operators, but unknown operators fall back to the default unimplemented rendering. This change gives downstream applications a generic way to provide their own rendering behavior while keeping plan-viz independent of any one downstream project.

## Test Plan

- `npm run lint`
- `npm run build`
- `npm test -- --watchman=false`

Jest result: 35 test suites passed, 482 tests passed.